### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 15
+    commit-message:
+      prefix: "build"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - ".github/workflows"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 15

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -13,9 +13,9 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
     - name: Set up Ruby 2.6
-      uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1
+      uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 #v1
       with:
         ruby-version: '2.6'
     

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -13,9 +13,9 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Set up Ruby 2.6
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1
       with:
         ruby-version: '2.6'
     


### PR DESCRIPTION
## Description

Pin all GitHub Actions in this repository to immutable commit SHAs.
Actions pinned to mutable tags or branch refs (e.g. `@v4`, `@main`) are vulnerable
to supply chain attacks — if an upstream maintainer's account is compromised, the tag
can be silently moved to a malicious commit and the next workflow run will execute it.

Dependabot is configured (or updated) in this PR to keep the pinned SHAs current
automatically, so this is a one-time migration with no ongoing manual maintenance.

| Action | Was | Now |
| ------ | --- | --- |
| `actions/checkout` | `@v2` | `@ee0669bd...` |
| `ruby/setup-ruby` | `@v1` | `@0cb964fd...` |

## Reference

This PR was generated by the Platform Engineering `pin-actions` tool as part of the
organisation-wide GitHub Actions supply chain hardening initiative (DO-1616).

## Notes for reviewers

**Ownership note:** this PR was opened automatically on behalf of the team.
The author is a platform tooling script — merging is the responsibility of the
repository's code owners, not the platform team. Please review the pins and merge
at your convenience. Reach out to #platform-eng with any questions.

Each `uses:` line has been updated from `owner/repo@tag` to `owner/repo@sha # tag`.
The tag is preserved as an inline comment so the intent remains human-readable.
No workflow logic has been changed.

## Validation

SHA resolution was performed at PR creation time via the GitHub API
(`GET /repos/{owner}/{repo}/commits/{ref}`). Each SHA corresponds to the commit
the tag pointed to at that moment. Dependabot will keep them up to date going forward.